### PR TITLE
Set specific version of Werkeug==2.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Flask==2.2.2
+Werkzeug==2.2.2
 langchain==0.0.231
 webvtt_py==0.4.6
 openai==0.27.8


### PR DESCRIPTION
I received an error "ImportError: cannot import name 'url_quote' from 'werkzeug.urls'"

and based on information here:

https://stackoverflow.com/a/77214086

I found that setting an old version of Werkzeug fixed the issue.